### PR TITLE
Refactor two calls loss_batch(..) and grad_loss_batch(..) into a sing…

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,6 +122,10 @@ def main():
     grad_loss_batch_unjit = jax.grad(loss_batch, argnums=1)
     grad_loss_batch = jax.jit(grad_loss_batch_unjit, static_argnums=0)
 
+
+    value_and_grad_loss_batch_unjit = jax.value_and_grad(loss_batch, argnums=1)
+    value_and_grad_loss_batch = jax.jit(value_and_grad_loss_batch_unjit, static_argnums=0)
+
     matches = re.search("--xla_dump_to=([^ ]+)", os.environ.get("XLA_FLAGS") or "")
     if matches:
         fn = matches[1] + "/grad_loss_batch.jaxpr.py"
@@ -144,11 +148,8 @@ def main():
 
         # Iterate through batches
         for i, data in enumerate(islice(dataset, sys.maxsize if save() else 10)):
-            # Compute and log the loss
-            loss = loss_batch(cfg, params, data)
-
-            # Get the gradients
-            grads = grad_loss_batch(cfg, params, data)
+            # Get loss and gradients 
+            loss, grads = value_and_grad_loss_batch(cfg, params, data)
 
             # gnorms = jax.tree_map(lambda v:np.round(np.log((jnp.linalg.norm(v)))), grads)
             # if i == 0:


### PR DESCRIPTION
Changing training loop to use `jax.value_and_grad(..).` This removes a forward pass from the training loop => 5s faster execution on CPU. 

Running `python main.py` before change: 
```
dummy-bJxS6eyFjtsBr94T3kexFk loss 3.2920437 sample ell-apparell'd April on the heel
WARNING:timer.sample:start
3.2920437 Au|  e  e  e  e e  e  e
WARNING:timer.sample:cost 807 ms
TIME: 50.904489278793335
```

Running `python main.py` after change. 
```
dummy-UdYk93YwDmF6bfSecce4Cn loss 3.2920437 sample ks be sour.\n\nSIR STEPHEN SCROOP:
WARNING:timer.sample:start
3.2920437 Au|  e  e  e  e e  e  e
WARNING:timer.sample:cost 858 ms
TIME: 45.6448495388031
```

**OBS:**
Chose not to delete the following two lines as they are used other places where we only need grad. 
```
grad_loss_batch_unjit = jax.grad(loss_batch, argnums=1)
grad_loss_batch = jax.jit(grad_loss_batch_unjit, static_argnums=0)
```
