### PR TITLE
Real shape annotations, remove some cruft

### DIFF
--- a/main.py
+++ b/main.py
@@ -161,10 +161,11 @@ def main():
                 # Get loss and gradients
                 loss, grads = value_and_grad_loss_batch(cfg, params, data)
 
-                print(f"{wandb.run.name} {loss=} sample {tostr(data[0])}")
+                # print(f"{wandb.run.name} loss {loss.item()} data {tostr(data[0])}")
                 total_time = time.time() - start
 
                 wandb.log({"time": total_time, "batch": i, "loss": loss})
+
                 # Update parameters
                 if sgd():
                     params = tree_axpy(-lr(), grads, params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 wandb
 jax
+jaxtyping
 torch # until awfutils moves to optree
 -e timer/.
 -e awfutils/.


### PR DESCRIPTION
The big change here is real shape annotations.  Where we used to have
```py
   query = linear(head.query, t1)        # L x Dk
```
we now have
```py
   query : LxDk = linear(head.query, t1)
```
