### PR TITLE
Remove bias from the linears, it's clearer and Karpathy says "a bit better and faster"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
-    "editor.formatOnSave": true,
-    "python.formatting.provider": "black"
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "jupyter.debugJustMyCode": false,
+  "debugpy.debugJustMyCode": false,
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ def transformer(cfg, params, x: Int[Array, "L"]):
     """
     L, = x.shape # x is just 1D. Vmap/pmap will handle batching
 
-    # Make shape checkers for awfutils.typecheck
+    # Make shape checkers (https://github.com/awf/awfutils?tab=readme-ov-file#typecheck)
     LxL = lambda x: x.shape == (L, L)
     LxDk = lambda x: x.shape == (L, cfg.d_k)
     LxDff = lambda x: x.shape == (L, cfg.d_ff)

--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ def main():
 
     sgd = Arg("sgd", False, "Pure sgd")
 
+    test_data = jnp.hstack([*islice(dataset, 4)])
     # grad_loss_batch = jax.pjit(grad_loss_batch_unjit, static_argnums=0)
 
     optimizer = Adam(params, lr=lr(), betas=(beta1(), beta2()))
@@ -173,18 +174,16 @@ def main():
                     params = optimizer.step(params, grads)
 
         # Log a sample after each epoch
-        with timer("sample and loss"):
-            test_data = jnp.hstack([*islice(dataset, 4)])
-            loss = loss_batch(cfg, params, test_data)
+        test_loss = loss_batch(cfg, params, test_data)
 
+        print(f"E{epoch} test={test_loss:.3f}")
+        if epoch % 25 == 0:
+          with timer("sample"):
             prompt = [dataset.stoi[c] for c in "Au"]
             sampled = transformer_sample(
                 cfg, params, jnp.array(prompt), length=20 + epoch
-            )
-            print(
-                f"E{epoch} L{loss:.3f}",
-                f"Sample [{tostr(prompt)}|{tostr(sampled[len(prompt):])}]",
-            )
+            ) 
+            print(f"Sample [{tostr(prompt)}|{tostr(sampled[len(prompt):])}]")
 
     # Grab Current Time After Running the Code
     end = time.time()

--- a/main.py
+++ b/main.py
@@ -97,9 +97,9 @@ def main():
         rnd_key,
         dataset.n_tokens,
         d_model=d_model(),
-        d_k=d_k(),
         n_layers=n_layers(),
         n_heads=heads(),
+        d_k=d_k(),
         d_ff=d_ff(),
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wandb
-jax
+jax[cuda]==0.5
 jaxtyping
 torch # until awfutils moves to optree
 -e timer/.

--- a/transformer.py
+++ b/transformer.py
@@ -49,16 +49,6 @@ def matrix_init_uniform(rng: jax.random.PRNGKey, in_features: int, out_features:
     )
 
 
-def linear_init_uniform(rng: jax.random.PRNGKey, in_features: int, out_features: int):
-    """
-    Initialize a linear layer with uniform weights and zero bias
-    """
-    params = ParamsDict()
-    rng, params.weight = matrix_init_uniform(rng, in_features, out_features)
-    params.bias = jnp.zeros((out_features,))
-    return rng, params
-
-
 # Layer norm
 def elementwise_linear_init_identity(shape):
     """


### PR DESCRIPTION
Removing bias, so 
```
  t1 = elementwise_linear(layer.norm_self_attn, t1)
  ...
  for head in layer.heads:
      # Project into this head's query/key space
      query : LxDk = linear(head.query, t1)
        key : LxDk = linear(head.key, t1)
```
becomes
```
  t1 : LxDm = t1 @ jnp.diag(layer.norm_self_attn)
  ...
  for head in layer.heads:
      # Project into this head's query/key space
      query : LxDk = t1 @ head.query
          key : LxDk = t1 @ head.key
```
Which is more in the "pure numpy" spirit.

And anyway, Karpathy says it's "[a bit better and faster](https://github.com/karpathy/nanoGPT/blob/93a43d9a5c22450bbf06e78da2cb6eeef084b717/model.py#L116)"

Training loss.
Blue: old, bias=True;
Yellow: new, bias=False
![image](https://github.com/user-attachments/assets/2f449826-be2a-4e81-bee8-5e31bd4aaad0)
